### PR TITLE
Refactor Dashboard and MyArticles pages to fetch articles from API an…

### DIFF
--- a/front-end/src/data/mockData.js
+++ b/front-end/src/data/mockData.js
@@ -1,138 +1,119 @@
-//TEMPORARY, fix by tonight
-export const mockArticles = [
-  {
-    // Unique identifier for the article
-    "id": "article_1001",
+const POSTS_API_URL = "https://dummyjson.com/posts?limit=24";
+const USERS_API_URL = "https://randomuser.me/api/?results=24&nat=us,ca,au,gb";
 
-    // Header & Meta information
-    "sourceName": "KNOWLEDGE KITCHEN PRESS", // The publisher or media outlet
-    "title": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
-    "author": "Mumu Li", // Author of the article
-    "publishDate": "02-25-2026",
-    "coverImageUrl": "https://dummyimage.com/600x400/cccccc/ffffff&text=News+Image", // Placeholder cover image
-    "isBookmarked": true, // Determines if the star icon is filled (saved by user)
-    "isSubmitted": true, // Submitted by this user for analysis
-    "status": "analyzed", // "pending" | "analyzed"
-
-    // Bias and Sentiment Analysis Data
-    "analysis": {
-      "bias": {
-        "label": "CENTER-LEFT", // Text displayed above the slider
-        "score": -0.3 // Range: -1.0 (Far Left) to 1.0 (Far Right), 0 is Neutral. Used to position the triangle on the slider.
-      },
-      "sentiment": {
-        "label": "NEUTRAL",
-        "score": 0.0 // Range: -1.0 (Negative) to 1.0 (Positive). Used to position the triangle on the slider.
-      }
-    },
-
-    // Content for the List View
-    "summary": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, ....", // Short snippet for the list card
-
-    // Content for the Detail View (Pure Text + Highlight Indices)
-    "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
-
-    // Array of objects defining which parts of the 'content' string should be highlighted
-    "highlights": [
-      {
-        "startIndex": 71, // The character index where the highlight begins (inclusive)
-        "endIndex": 147,  // The character index where the highlight ends (exclusive)
-        "type": "bias-indicator", // We want different background colors later (see https://owl.purdue.edu/owl/general_writing/academic_writing/logic_in_argumentative_writing/fallacies.html)
-        "description": "This phrase indicates a center-left leaning bias." // We want to show a tooltip when tapping the highlight
-      }
-    ]
-  },
-  {
-    "id": "article_1002",
-    "sourceName": "GLOBAL NEWS NETWORK",
-    "title": "Understanding the global economic shifts in early 2026",
-    "author": "Alex Smith",
-    "publishDate": "2026-03-15",
-    "coverImageUrl": "https://dummyimage.com/600x400/e0e0e0/000000&text=Economy+News",
-    "isBookmarked": false,
-    "isSubmitted": true,
-    "status": "analyzed",
-    "analysis": {
-      "bias": {
-        "label": "CENTER-RIGHT",
-        "score": 0.4
-      },
-      "sentiment": {
-        "label": "POSITIVE",
-        "score": 0.6
-      }
-    },
-    "summary": "A deep dive into the recent market trends and what they mean for international trade agreements moving forward...",
-    "content": "A deep dive into the recent market trends and what they mean for international trade agreements moving forward. Experts suggest that the new policies will heavily favor corporate deregulation, which has sparked a massive debate among policymakers. While some argue it will boost the GDP, others fear it will widen the wealth gap.",
-    "highlights": [
-      {
-        "startIndex": 136,
-        "endIndex": 182,  // Highlights: "heavily favor corporate deregulation"
-        "type": "bias-indicator",
-        "description": "Right-leaning economic policy framing."
-      }
-    ]
-  },
-  {
-    "id": "article_1003",
-    "sourceName": "KNOWLEDGE KITCHEN PRESS",
-    "title": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
-    "author": "Kevin Pham",
-    "publishDate": "03-10-2026",
-    "coverImageUrl": "https://dummyimage.com/600x400/cccccc/ffffff&text=News+Image",
-    "isBookmarked": true,
-    "isSubmitted": true,
-    "status": "pending",
-    "analysis": {
-      "bias": {
-        "label": "CENTER-LEFT",
-        "score": -0.3
-      },
-      "sentiment": {
-        "label": "NEUTRAL",
-        "score": 0.0
-      }
-    },
-    "summary": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, ....",
-    "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
-    "highlights": [
-      {
-        "startIndex": 71,
-        "endIndex": 147,
-        "type": "bias-indicator",
-        "description": "This phrase indicates a center-left leaning bias."
-      }
-    ]
-  },
-  {
-    "id": "article_1004",
-    "sourceName": "KNOWLEDGE KITCHEN PRESS",
-    "title": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
-    "author": "Kevin Pham",
-    "publishDate": "03-20-2026",
-    "coverImageUrl": "https://dummyimage.com/600x400/cccccc/ffffff&text=News+Image",
-    "isBookmarked": false,
-    "isSubmitted": true,
-    "status": "pending",
-    "analysis": {
-      "bias": {
-        "label": "CENTER-LEFT",
-        "score": -0.3
-      },
-      "sentiment": {
-        "label": "NEUTRAL",
-        "score": 0.0
-      }
-    },
-    "summary": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, ....",
-    "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
-    "highlights": [
-      {
-        "startIndex": 71,
-        "endIndex": 147,
-        "type": "bias-indicator",
-        "description": "This phrase indicates a center-left leaning bias."
-      }
-    ]
+const toLabel = (score, type) => {
+  if (type === "sentiment") {
+    if (score > 0.2) return "POSITIVE";
+    if (score < -0.2) return "NEGATIVE";
+    return "NEUTRAL";
   }
-];
+
+  if (score <= -0.7) return "LEFT";
+  if (score <= -0.25) return "CENTER-LEFT";
+  if (score >= 0.7) return "RIGHT";
+  if (score >= 0.25) return "CENTER-RIGHT";
+  return "CENTER";
+};
+
+const clamp = (num, min, max) => Math.max(min, Math.min(max, num));
+
+const titleCase = (value) =>
+  value
+    .split(" ")
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(" ");
+
+const shortText = (value, maxLen = 145) => {
+  const trimmed = value.trim();
+  if (trimmed.length <= maxLen) {
+    return trimmed;
+  }
+
+  return `${trimmed.slice(0, maxLen).trimEnd()}...`;
+};
+
+const makeHighlight = (content, keyword) => {
+  if (!keyword) {
+    return [];
+  }
+
+  const idx = content.toLowerCase().indexOf(keyword.toLowerCase());
+  if (idx === -1) {
+    return [];
+  }
+
+  return [
+    {
+      startIndex: idx,
+      endIndex: idx + keyword.length,
+      type: "bias-indicator",
+      description: "Model-highlighted phrase for faster manual review."
+    }
+  ];
+};
+
+const buildSourceName = (user) => {
+  const city = user?.location?.city;
+  const country = user?.location?.country;
+  const seed = city || country || "Global";
+  return `${seed.toUpperCase()} WIRE`;
+};
+
+const buildArticle = (post, user, index) => {
+  const likes = post?.reactions?.likes ?? post?.reactions ?? 0;
+  const dislikes = post?.reactions?.dislikes ?? 0;
+  const reactionTotal = Math.max(1, likes + dislikes);
+  const sentimentScore = clamp((likes - dislikes) / reactionTotal, -1, 1);
+
+  const views = post?.views ?? 200;
+  const biasScore = clamp(((views % 100) - 50) / 50, -1, 1);
+
+  const publishDate = new Date(Date.now() - (index + 1) * 86400000).toISOString().slice(0, 10);
+  const content = `${post.body} Analysis signals and framing cues were detected by the prototype model.`;
+  const keyword = post?.tags?.[0] || post?.title?.split(" ")?.[0] || "";
+
+  return {
+    id: `article_${post.id}`,
+    sourceName: buildSourceName(user),
+    title: titleCase(post.title),
+    author: `${user?.name?.first || "Unknown"} ${user?.name?.last || "Author"}`,
+    publishDate,
+    coverImageUrl: `https://picsum.photos/seed/${post.id}/640/420`,
+    isBookmarked: likes % 2 === 0,
+    isSubmitted: index % 5 !== 0,
+    status: index % 4 === 0 ? "pending" : "analyzed",
+    analysis: {
+      bias: {
+        label: toLabel(biasScore, "bias"),
+        score: biasScore
+      },
+      sentiment: {
+        label: toLabel(sentimentScore, "sentiment"),
+        score: sentimentScore
+      }
+    },
+    summary: shortText(post.body),
+    content,
+    highlights: makeHighlight(content, keyword)
+  };
+};
+
+export async function fetchMockArticles() {
+  const [postsRes, usersRes] = await Promise.all([
+    fetch(POSTS_API_URL),
+    fetch(USERS_API_URL)
+  ]);
+
+  if (!postsRes.ok || !usersRes.ok) {
+    throw new Error("Unable to fetch mock data from external providers.");
+  }
+
+  const postsPayload = await postsRes.json();
+  const usersPayload = await usersRes.json();
+
+  const posts = Array.isArray(postsPayload?.posts) ? postsPayload.posts : [];
+  const users = Array.isArray(usersPayload?.results) ? usersPayload.results : [];
+
+  return posts.map((post, index) => buildArticle(post, users[index % users.length], index));
+}

--- a/front-end/src/pages/DashboardPage.jsx
+++ b/front-end/src/pages/DashboardPage.jsx
@@ -1,16 +1,49 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import './DashboardPage.css'
 import ArticleCard from "../components/ArticleCard";
-import { mockArticles } from "../data/mockData"; //TEMPORARY
+import { fetchMockArticles } from "../data/mockData";
 function DashboardPage() {
 
   const [searchTerm, setSearchTerm] = useState("");
-  
-  //need to inject mock data for article list
-  //then filter using searchterm
-  
-  
-  
+  const [articles, setArticles] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadArticles = async () => {
+      try {
+        const payload = await fetchMockArticles();
+        if (isMounted) {
+          setArticles(payload);
+        }
+      } catch (err) {
+        if (isMounted) {
+          setError(err.message || "Could not load article feed.");
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    loadArticles();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const filteredArticles = useMemo(
+    () =>
+      articles.filter((article) =>
+        article.title.toLowerCase().includes(searchTerm.toLowerCase())
+      ),
+    [articles, searchTerm]
+  );
+
   return <div className="dashboard-page">
       <div className="dashboard-title">Recent Articles</div>
       <div className="dashboard-subtitle">Articles with bias analysis</div>
@@ -26,27 +59,24 @@ function DashboardPage() {
       </div>
 
       <div className="articles-list">
-          
-          {mockArticles.map((article) => {
-            if (article.title.toLowerCase().includes(searchTerm.toLowerCase())){
-              return <ArticleCard
-              key={article.id}
-              id={article.id}
-              source={article.sourceName}
-              title={article.title}
-              summary={article.summary}
-              date={article.publishDate}
-              sentiment={article.analysis.sentiment.label}
-              bias={article.analysis.bias.label}
-              thumbnail={article.coverImageUrl}
-              isBookmarked={article.isBookmarked}
-              status={article.status}
-            />
-            }
-            
-        })}
-        
-          
+        {loading && <div>Loading articles...</div>}
+        {!loading && error && <div>{error}</div>}
+
+        {!loading && !error && filteredArticles.map((article) => (
+          <ArticleCard
+            key={article.id}
+            id={article.id}
+            source={article.sourceName}
+            title={article.title}
+            summary={article.summary}
+            date={article.publishDate}
+            sentiment={article.analysis.sentiment.label}
+            bias={article.analysis.bias.label}
+            thumbnail={article.coverImageUrl}
+            isBookmarked={article.isBookmarked}
+            status={article.status}
+          />
+        ))}
       </div>
 
   </div>

--- a/front-end/src/pages/MyArticlesPage.jsx
+++ b/front-end/src/pages/MyArticlesPage.jsx
@@ -1,19 +1,58 @@
-import { useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import ArticleCard from '../components/ArticleCard'
-import { mockArticles } from '../data/mockData'
+import { fetchMockArticles } from '../data/mockData'
 import './MyArticlesPage.css'
 
 function MyArticlesPage() {
   const [activeTab, setActiveTab] = useState('submitted')
+  const [articles, setArticles] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
   const navigate = useNavigate()
 
-  const submittedArticles = mockArticles
-    .filter(a => a.isSubmitted)
-    .sort((a, b) => (a.status === 'pending' ? -1 : 1) - (b.status === 'pending' ? -1 : 1))
-  const savedArticles = mockArticles
-    .filter(a => a.isBookmarked)
-    .sort((a, b) => (a.status === 'pending' ? -1 : 1) - (b.status === 'pending' ? -1 : 1))
+  useEffect(() => {
+    let isMounted = true
+
+    const loadArticles = async () => {
+      try {
+        const payload = await fetchMockArticles()
+        if (isMounted) {
+          setArticles(payload)
+        }
+      } catch (err) {
+        if (isMounted) {
+          setError(err.message || 'Could not load articles.')
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false)
+        }
+      }
+    }
+
+    loadArticles()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  const submittedArticles = useMemo(
+    () =>
+      articles
+        .filter(a => a.isSubmitted)
+        .sort((a, b) => (a.status === 'pending' ? -1 : 1) - (b.status === 'pending' ? -1 : 1)),
+    [articles]
+  )
+
+  const savedArticles = useMemo(
+    () =>
+      articles
+        .filter(a => a.isBookmarked)
+        .sort((a, b) => (a.status === 'pending' ? -1 : 1) - (b.status === 'pending' ? -1 : 1)),
+    [articles]
+  )
 
   const displayedArticles = activeTab === 'submitted' ? submittedArticles : savedArticles
 
@@ -44,7 +83,9 @@ function MyArticlesPage() {
       </div>
 
       <div className="articles-list">
-        {displayedArticles.map(article => (
+        {loading && <div>Loading articles...</div>}
+        {!loading && error && <div>{error}</div>}
+        {!loading && !error && displayedArticles.map(article => (
           <ArticleCard
             key={article.id}
             id={article.id}


### PR DESCRIPTION
PLEASE READ: 

I used three public mock providers so front-end no longer stores backend-like records inline:

- Posts source: [dummyjson.com](https://dummyjson.com/posts?limit=24) - It gives article-like text content.
- User source: [randomuser.me](https://randomuser.me/api/?results=24&nat=us,ca,au,gb) - It gives author/source metadata.
- Image source: [picsum](https://picsum.photos/seed/{id}/640/420) - It gives realistic, unique thumbnails per article ID
- These live in front-end/src/data/mockData.js.

The fetch layer transforms external responses into our existing shape before pages use it.
So frontend still receive:
- id
- sourceName
- title
- author
- publishDate
- coverImageUrl
- isBookmarked
- isSubmitted
- status
- analysis.bias.label
- analysis.bias.score
- analysis.sentiment.label
- analysis.sentiment.score
- summary
- content
- highlights[{ startIndex, endIndex, type, description }]

That mapping is all in front-end/src/data/mockData.js.



# TLDR

- id: article_{post.id}
- title/body: from DummyJSON post title/body
- author: from RandomUser first + last name
- sourceName: generated from user city/country
- coverImageUrl: Picsum seeded by post.id
- publishDate: generated recent dates
- analysis scores:
- sentiment from likes/dislikes ratio
- bias from views-derived deterministic formula
- status/isSubmitted/isBookmarked: deterministic booleans for realistic variety
- highlights: keyword location found in content


What Changed in Pages:

- Only data loading style changed.
- front-end/src/pages/DashboardPage.jsx now calls fetchMockArticles()
- front-end/src/pages/MyArticlesPage.jsx now calls fetchMockArticles()
- Card props and rendering expectations were not changed.
- **One contract-level change did happen at module API level:**
  - Before: exported mockArticles static array
  - Now: exported fetchMockArticles async function