### PR TITLE
Added Bias Analytics Page

### DIFF
--- a/front-end/src/pages/AnalyticsPage.css
+++ b/front-end/src/pages/AnalyticsPage.css
@@ -1,0 +1,97 @@
+.analytics-page {
+  min-height: 100vh;
+  max-width: 420px;
+  margin: 0 auto;
+  padding: 20px 16px 90px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.analytics-status {
+  font-size: 0.9rem;
+  color: #6b7280;
+}
+
+/* Header row: title left, dropdown right */
+.analytics-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.analytics-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.analytics-subtitle {
+  font-size: 0.95rem;
+  color: #6b7280;
+}
+
+.time-range-select {
+  margin-top: 4px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1.5px solid #111827;
+  background: #111827;
+  color: white;
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  outline: none;
+}
+
+/* Quick stats card */
+.stats-card {
+  background: white;
+  border: 1px solid #eef0f5;
+  border-radius: 8px;
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.stat-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+}
+
+.stat-number {
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: #111827;
+}
+
+.stat-label {
+  font-size: 1rem;
+  color: #6b7280;
+  margin-left: 6px;
+}
+
+/* Chart placeholder cards */
+.chart-card {
+  background: white;
+  border: 1px solid #eef0f5;
+  border-radius: 8px;
+  padding: 14px;
+}
+
+.chart-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #6b7280;
+  margin-bottom: 10px;
+}
+
+.chart-placeholder {
+  width: 100%;
+  height: 180px;
+  background-color: #e5e7eb;
+  border-radius: 4px;
+}

--- a/front-end/src/pages/AnalyticsPage.jsx
+++ b/front-end/src/pages/AnalyticsPage.jsx
@@ -1,5 +1,90 @@
+import { useEffect, useMemo, useState } from 'react'
+import { fetchMockArticles } from '../data/mockData'
+import './AnalyticsPage.css'
+
 function AnalyticsPage() {
-  return <h1>Analytics Page</h1>
+  const [timeRange, setTimeRange] = useState('Past Month')
+  const [articles, setArticles] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let isMounted = true
+
+    const loadArticles = async () => {
+      try {
+        const payload = await fetchMockArticles()
+        if (isMounted) setArticles(payload)
+      } catch (err) {
+        if (isMounted) setError(err.message || 'Could not load articles.')
+      } finally {
+        if (isMounted) setLoading(false)
+      }
+    }
+
+    loadArticles()
+    return () => { isMounted = false }
+  }, [])
+
+  const analyzed = useMemo(() => articles.filter(a => a.status === 'analyzed'), [articles])
+
+  const articlesCount = analyzed.length
+  const avgBias = analyzed.length
+    ? (analyzed.reduce((sum, a) => sum + a.analysis.bias.score, 0) / analyzed.length).toFixed(2)
+    : 0
+  const avgSentiment = analyzed.length
+    ? (analyzed.reduce((sum, a) => sum + a.analysis.sentiment.score, 0) / analyzed.length).toFixed(2)
+    : 0
+
+  return (
+    <div className="analytics-page">
+
+      <div className="analytics-header">
+        <div>
+          <div className="analytics-title">Bias Analytics</div>
+          <div className="analytics-subtitle">Visual Insights and Statistics</div>
+        </div>
+        <select
+          className="time-range-select"
+          value={timeRange}
+          onChange={(e) => setTimeRange(e.target.value)}
+        >
+          <option>Past Week</option>
+          <option>Past Month</option>
+          <option>Past Year</option>
+        </select>
+      </div>
+
+      {loading && <div className="analytics-status">Loading...</div>}
+      {!loading && error && <div className="analytics-status">{error}</div>}
+
+      <div className="stats-card">
+        <div className="stat-row">
+          <span className="stat-number">{articlesCount}</span>
+          <span className="stat-label"> articles analyzed</span>
+        </div>
+        <div className="stat-row">
+          <span className="stat-number">{avgBias > 0 ? `+${avgBias}` : avgBias}</span>
+          <span className="stat-label"> average bias</span>
+        </div>
+        <div className="stat-row">
+          <span className="stat-number">{avgSentiment > 0 ? `+${avgSentiment}` : avgSentiment}</span>
+          <span className="stat-label"> average sentiment</span>
+        </div>
+      </div>
+
+      <div className="chart-card">
+        <div className="chart-label">Chart 1 - Bias Distribution</div>
+        <div className="chart-placeholder" />
+      </div>
+
+      <div className="chart-card">
+        <div className="chart-label">Chart 2 - Sentiment Trend</div>
+        <div className="chart-placeholder" />
+      </div>
+
+    </div>
+  )
 }
 
 export default AnalyticsPage


### PR DESCRIPTION
This page was made to look almost exactly like the Stats Page.png. The dropdown does not work yet as it only takes in === analyzed and will be adjusted later. The articles analyzed comes from the mock data and takes the total amount of articles that have been considered "finished". Bias score and sentiment score is made from the mock data. No actual charts have been made and are only there for display and have been styled so that they look like the wireframe.